### PR TITLE
docs: Add overview of architecture in handoff docs

### DIFF
--- a/docs/hand-off-documentation/next-steps.md
+++ b/docs/hand-off-documentation/next-steps.md
@@ -6,6 +6,8 @@ sidebar_position: 3
 
 # What’s next?
 
-- Review **open issues** tagged `good‑first‑issue`.
-- Read the **Credits** page to know who’s who.
-- Check **ACKNOWLEDGEMENTS** for external resources we rely on.
+- Explore the code structure to be familiar with pages/, components/, and styles/.
+- Add pages to the website redesign from the original design, such as info on the people working on Sokana and a calendar for upcoming events. 
+- Add appropriate courses to the courses page with admin accounts. 
+- Translate key course content and educational materials into Spanish, ensuring that key components like buttons, navigation, and input fields have necessary support.
+- Implement page and Stripe payment for Sokana Collective merchandise and gift cards. 

--- a/docs/hand-off-documentation/overview.md
+++ b/docs/hand-off-documentation/overview.md
@@ -6,30 +6,56 @@ sidebar_position: 2
 
 # System at a glance
 
-Below is the 10 000‑foot view of how **AwesomeProject** fits together.
+Below are the frontend and backend tech stacks of the **Sokana Collective Website**, as well as the key directories for each of the repositories.
 
-| Layer            | Main tech         | Responsibility                    |
-| ---------------- | ----------------- | --------------------------------- |
-| UI               | React 18 + MDX    | Renders docs & pages              |
-| Static generator | Docusaurus 2      | Converts MD/MDX to static HTML    |
-| Styling          | Tailwind CSS      | Utility‑first styling & dark mode |
-| Search           | Algolia DocSearch | Client‑side full‑text search      |
-| Hosting          | Netlify / Vercel  | CDN‑backed static hosting         |
+### Frontend
+
+| Framework           | Purpose                        |
+| ------------------- | -------------------------------|
+| React               | UI components.                 |
+| React Router v7     | Navigation across pages.       |
+| styled-components   | Styling components.            |
+| Supabase            | Authentication.                |
+
+### Backend
+
+| Framework           | Purpose                        |
+| ------------------- | -------------------------------|
+| Node.js, Express    | Server-side logic.             |
+| PostgreSQL          | Used via Supabase for database.|
+| ESLint, Prettier    | Consistent code formatting.    |
 
 ## Key directories
 
+### Frontend
 ```
-docs/                → Markdown documentation
-src/                 → React pages & components
-static/              → Images, favicons, robots.txt…
-docusaurus.config.js → Global site config
-sidebars.js          → Sidebar structure
+src/    → Contains the source code for the React application, including components, pages, and other related files.
+
+public/ → Holds static assets such as the index.html file, images, and other resources that are publicly accessible.
+
+.github/ → Contains GitHub-specific configurations, such as workflows for GitHub Actions.
+
+.vscode/ → Includes settings specific to Visual Studio Code, which can help maintain consistent development environments.
+```
+
+### Backend 
+```
+src/     → Houses the source code for the backend application, including route handlers, middleware, and other server-side logic.
+
+uploads/ → Used for storing uploaded files, such as images or documents, that are handled by the backend.
+
+.github/ → Contains GitHub-specific configurations, such as workflows for GitHub Actions.
+
+.vscode/ → Includes settings specific to Visual Studio Code, which can help maintain consistent development environments.
 ```
 
 ## Decision log (abridged)
 
-| Date       | Choice                        | Rationale                                              |
-| ---------- | ----------------------------- | ------------------------------------------------------ |
-| 2025‑04‑10 | Chose Docusaurus over Next.js | Built‑in versioned docs saved weeks of boilerplate     |
-| 2025‑04‑14 | Switched CSS to Tailwind      | Faster prototyping, consistent design tokens           |
-| 2025‑04‑20 | Enabled Algolia search        | >10× better discoverability for long‑tail docs queries |
+| Choice                             | Rationale                                                             |
+| ---------------------------------- | --------------------------------------------------------------------- |
+| Chose **React** for frontend       | Standard modern framework with component reusability                  |
+| Used **Tailwind** CSS              | Utility-first styling for fast prototyping and consistency            |
+| Backend built with **Express.js**  | Lightweight, flexible Node.js framework                               |
+| Chose **Supabase** for backend     | Open-source Firebase alternative; built-in auth and Postgres database |
+| Adopted **Docusaurus** for docs    | Built-in docs support, versioning, and quick setup                    |
+

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -40,7 +40,7 @@ const config: Config = {
           sidebarPath: require.resolve("./sidebars.documentation.ts"),
           routeBasePath: "/",
           editUrl:
-            "https://github.com/disc-sweb/docs-template/edit/main/docs/",
+            "https://github.com/disc-sweb/docs-template/edit/main/",
         },
         theme: {
           customCss: "./src/css/custom.css",


### PR DESCRIPTION
Add overview of architecture, including tech stack of frontend and backend. Explains rationale behind each part of the tech stack, and gives a brief description of key directories in both the frontend and backend. 